### PR TITLE
Feature/fix naming release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,16 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -la ./artifacts/
 
+      - name: Rename binaries for release
+        run: |
+          mv ./artifacts/deck_cli-linux/deck_cli ./artifacts/deck_cli-linux
+          mv ./artifacts/deck_cli-macos/deck_cli ./artifacts/deck_cli-macos
+          mv ./artifacts/deck_cli-windows.exe/deck_cli.exe ./artifacts/deck_cli-windows.exe
+          rm -rf ./artifacts/deck_cli-linux/
+          rm -rf ./artifacts/deck_cli-macos/
+          rm -rf ./artifacts/deck_cli-windows.exe/
+          ls -la ./artifacts/
+
       - name: Generate release tag
         id: tag
         run: |
@@ -129,9 +139,9 @@ jobs:
             - macOS: deck_cli-macos  
             - Windows: deck_cli-windows.exe
           files: |
-            ./artifacts/deck_cli-linux/deck_cli
-            ./artifacts/deck_cli-macos/deck_cli
-            ./artifacts/deck_cli-windows.exe/deck_cli.exe
+            ./artifacts/deck_cli-linux
+            ./artifacts/deck_cli-macos
+            ./artifacts/deck_cli-windows.exe
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
After getting this issue:

```sh
 👩‍🏭 Creating new GitHub release for tag v2025.07.11-979b54d...
⬆️ Uploading deck_cli...
⬆️ Uploading deck_cli...
⬆️ Uploading deck_cli.exe...
Error: Failed to upload release asset deck_cli. received status code 422
Validation Failed
[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]
```

i think i cant duplicate artifact names, so now i'm making sure every build has its platform on their name.

Hopefully this will make the release work 🤞 !